### PR TITLE
Removed lodash.mapValues dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "fbjs": "^0.8.16",
     "lodash.invert": "^4.3.0",
     "lodash.isempty": "^4.4.0",
-    "lodash.mapvalues": "^4.6.0",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {

--- a/src/states.js
+++ b/src/states.js
@@ -1,5 +1,3 @@
-import mapValues from "lodash.mapvalues"
-
 const STATES = {
   appear: "appear",
   appearActive: "appear-active",
@@ -9,6 +7,9 @@ const STATES = {
   exitActive: "exit-active"
 }
 
-export const classNames = id => mapValues(STATES, type => `${id}-${type}`)
+export const classNames = id => Object.keys(STATES).reduce((result, type) => {
+  result[type] = `${id}-${STATES[type]}`
+  return result
+}, {})
 
 export default STATES

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,10 +2471,6 @@ lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
-lodash.mapvalues@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
I noticed this library requires `lodash.mapValues` dependency that has bigger size than library itself:

<img width="496" alt="screen shot 2018-06-02 at 10 39 19" src="https://user-images.githubusercontent.com/950216/40872170-9dde514e-6652-11e8-91d7-3b249313cbcc.png">

In this PR I suggest to use simple `Object.keys/reduce` block instead of this dependency. That reduces `gziped` version of my application bundle by `3.53 KB`:

<img width="484" alt="screen shot 2018-06-02 at 10 39 05" src="https://user-images.githubusercontent.com/950216/40872171-9dfb3642-6652-11e8-96e7-7f4a1d8b6843.png">
