### PR TITLE
Replace Object.values to Object.keys for IE compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "styled-transition-group",
+  "name": "@lesechos/styled-transition-group",
   "description": "Write react-transition-group animations with styled-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/bundle.js",
   "author": "Gabriela Seabra <gabriela.lima.se@gmail.com>",
-  "repository": "gabiseabra/styled-transition-group",
+  "repository": "LesEchos/styled-transition-group",
   "license": "MIT",
   "scripts": {
     "prepublishOnly": "yarn run clean && yarn run build",

--- a/src/construct/css.js
+++ b/src/construct/css.js
@@ -5,7 +5,7 @@ import STATES from "../states"
 
 const STATES_BY_NAME = invert(STATES)
 
-const PATTERN = new RegExp(`([^\\s;}]+|^):(${Object.values(STATES).join("|")})(?=[\\s\\+~,{])`, "g")
+const PATTERN = new RegExp(`([^\\s;}]+|^):(${Object.keys(STATES).map(key => STATES[key]).join("|")})(?=[\\s\\+~,{])`, "g")
 
 const getClassName = state => props => `&.${props.transitionClassNames[state]}`
 


### PR DESCRIPTION
Hi, i replaced `Object.values` by `Object.keys`.

Indeed, `Object.values` isn't working on internet explorer:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values#Browser_compatibility

It can be fixed by mapping keys.