### PR TITLE
Add module property to package.json for ES Module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Write react-transition-group animations with styled-components",
   "version": "2.0.0",
   "main": "dist/bundle.js",
+  "module": "dist/bundle.es.js",
   "author": "Gabriela Seabra <gabriela.lima.se@gmail.com>",
   "repository": "gabiseabra/styled-transition-group",
   "license": "MIT",


### PR DESCRIPTION
This helps with other projects trying to treeshake.

I also believe the current published `dist/bundle.es.js` file is broken. Below is the code from the top of the file:

```js
import mapValues from 'lodash.mapvalues';
import invert from 'lodash.invert';
import styled, { css } from 'styled-components';
import isEmpty from 'lodash.isempty';
import React, { Component } from 'react';
import CSSTransition from 'react-transition-group/CSSTransition';

// 
// Thanks to ReactDOMFactories for this handy list!

var domElements = ['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'big', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'marquee', 'menu', 'menuitem', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'ruby', 's', 'samp', 'script', 'section', 'select', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr',

// SVG
'circle', 'clipPath', 'defs', 'ellipse', 'g', 'image', 'line', 'linearGradient', 'mask', 'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect', 'stop', 'svg', 'text', 'tspan'];

// 
var styled = (function (styledComponent, constructWithOptions) {
  var styled$$1 = function styled$$1(tag) {
    return constructWithOptions(styledComponent, tag);
  };

  // Shorthands for all valid HTML Elements
  domElements.forEach(function (domElement) {
    styled$$1[domElement] = styled$$1(domElement);
  });

  return styled$$1;
});
```

The `styled` variable is erroneously redefined and throws an error. When running Rollup on `styled-transition-group` locally this file is fine though, it has no such issue.
